### PR TITLE
basic board & tile setup

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,38 +1,6 @@
-.App {
-  text-align: center;
-}
-
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+html,
+body,
+.App,
+.App > div {
+  height: 100%;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import logo from './logo.svg';
 
-import ResourceTile from "./components/resource_tile/resource_tile";
 import './App.css';
 import 'bootstrap/dist/css/bootstrap.min.css';
+
+import PlayerBoard from "./components/player_board/player_board";
 
 function App() {
   return (
     <div className="App">
-      <header className="App-header">
-        <ResourceTile />
+      <PlayerBoard />
         {/* <img src={logo} className="App-logo" alt="logo" />
         <p>
           Edit <code>src/App.tsx</code> and save to reload.
@@ -22,7 +22,6 @@ function App() {
         >
           Learn React
         </a> */}
-      </header>
     </div>
   );
 }

--- a/src/components/generation_phase/generation_phase.css
+++ b/src/components/generation_phase/generation_phase.css
@@ -1,0 +1,3 @@
+.GenerationPhase {
+  flex: 1;
+}

--- a/src/components/generation_phase/generation_phase.tsx
+++ b/src/components/generation_phase/generation_phase.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+import "./generation_phase.css";
+
+// this should take in redux props modify data
+const GenerationPhase: React.FC<{}> = () => {
+    return (
+        <div className="GenerationPhase">
+            Generate
+        </div>
+    );
+}
+
+export default GenerationPhase;

--- a/src/components/player_board/player_board.css
+++ b/src/components/player_board/player_board.css
@@ -1,0 +1,15 @@
+.PlayerBoard {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  height: 100%;
+}
+
+.PlayerBoard-row {
+  display: flex;
+  flex: 2;
+}
+
+.PlayerBoard-header {
+  flex: 1;
+}

--- a/src/components/player_board/player_board.tsx
+++ b/src/components/player_board/player_board.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+import {Resource} from "../../utils/types";
+import ResourceTile from "../resource_tile/resource_tile";
+import GenerationPhase from "../../components/generation_phase/generation_phase";;
+
+import "./player_board.css";
+
+const PlayerBoard: React.FC<{}> = () => {
+    return (
+        <div className="PlayerBoard">
+            <div className="PlayerBoard-row PlayerBoard-header">
+                <ResourceTile resourceType={Resource.TerraformingRating}/>
+                <GenerationPhase />
+            </div>
+            <div className="PlayerBoard-row">
+                <ResourceTile resourceType={Resource.Megacredits}/>
+                <ResourceTile resourceType={Resource.Steel}/>
+                <ResourceTile resourceType={Resource.Titanium}/>
+                
+            </div>
+            <div className="PlayerBoard-row">
+                <ResourceTile resourceType={Resource.Plants}/>
+                <ResourceTile resourceType={Resource.Energy}/>
+                <ResourceTile resourceType={Resource.Heat}/>
+            </div>
+
+
+        </div>
+    );
+}
+
+export default PlayerBoard;

--- a/src/components/resource_tile/resource_tile.css
+++ b/src/components/resource_tile/resource_tile.css
@@ -1,0 +1,68 @@
+.ResourceTile {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+
+  border: 1px solid black;
+  margin: 4px;
+}
+
+.ResourceTile-label {
+  flex: 1;
+  padding: 12px;
+  font-size: large;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ResourceTile-label-text {
+  margin: auto;
+}
+
+.ResourceTile-availableValue {
+  flex: 2;
+  font-size: xx-large;
+  font-weight: bolder;
+  text-align: center;
+  padding: 20px;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  cursor: pointer;
+}
+
+.ResourceTile-productionSetter {
+  flex: 1;
+  margin: 10px;
+}
+
+.ProductionSetter {
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+
+  margin: auto 0;
+  height: 100%;
+}
+
+.Modal-currentResourceValue {
+  text-align: center;
+  padding: 10px;
+  border-radius: 4px;
+  font-size: x-large;
+}
+
+.Modal-userInput {
+  margin-top: 20px;
+  text-align: center;
+}
+
+.Modal-footer {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/components/resource_tile/resource_tile.tsx
+++ b/src/components/resource_tile/resource_tile.tsx
@@ -1,10 +1,40 @@
 import React from "react";
-
+import { Modal, InputGroup } from "react-bootstrap";
 import Button from "react-bootstrap/Button";
 
-const ResourceTile: React.FC<{}> = () => {
+import {Resource, ResourceToLabel} from "../../utils/types";
+
+import "./resource_tile.css";
+
+const ResourceToPrimaryColor = {
+    [Resource.TerraformingRating]: "#bd8e2f",
+    [Resource.Megacredits]: "#d4b82f",
+    [Resource.Steel]: "#754e2b",
+    [Resource.Titanium]: "#63605c",
+    [Resource.Plants]: "#42ad45",
+    [Resource.Energy]: "#911191",
+    [Resource.Heat]: "#cc411f",
+}
+
+const ResourceToSecondaryColor = {
+    [Resource.TerraformingRating]: "#edd4a1",
+    [Resource.Megacredits]: "#f2e8b3",
+    [Resource.Steel]: "#b58e6d",
+    [Resource.Titanium]: "#c4bcb1",
+    [Resource.Plants]: "#a4eba7",
+    [Resource.Energy]: "#f0a5f0",
+    [Resource.Heat]: "#f0927a",
+}
+
+interface ResourceTileProps {
+    resourceType: Resource;
+}
+
+const ResourceTile: React.FC<ResourceTileProps> = ({resourceType}) => {
+    const [showModal, setShowModal] = React.useState(false);
+
+    // value/production and setters will eventually be pulled from redux.
     const [value, setValue] = React.useState(0);
-    const [productionRate, setProductionRate] = React.useState(0);
 
 
     const handleClickIncrement = () => {
@@ -16,14 +46,155 @@ const ResourceTile: React.FC<{}> = () => {
     }
 
 
+    const handleClickGain = (gainedAmount: number) => {
+        setValue(prev => prev + gainedAmount);
+    }
+
+    const handleClickSpend = (spentAmount: number) => {
+        setValue(prev => prev - spentAmount);
+    }
+
 
     return (
-        <div>
-            <Button variant="primary" size="lg" onClick={handleClickDecrement}>-</Button>
-            <div>Value is: {value}</div>
-            <Button onClick={handleClickIncrement}>+</Button>
-  
+        <div 
+          className="ResourceTile"
+          style={{"backgroundColor": ResourceToSecondaryColor[resourceType]}}>
+            <div 
+              className="ResourceTile-label" 
+              style={{"backgroundColor": ResourceToPrimaryColor[resourceType]}}
+            >
+                <div className="ResourceTile-label-text">
+                    {ResourceToLabel[resourceType]}
+                </div>
+            </div>
+           
+           {resourceType !== Resource.TerraformingRating ? (
+                <div className="ResourceTile-availableValue" onClick={() => setShowModal(true)}>
+                    {value}
+                </div>
+            ) : null}
+
+            <div className="ResourceTile-productionSetter">
+                <ProductionSetter 
+                  resourceType={resourceType}
+                  currentValue={value}
+                  onDecrementValue={handleClickDecrement}
+                  onIncrementValue={handleClickIncrement} />
+            </div>
+
+
+            <ResourceSpendGainModal 
+              modalVisible={showModal} 
+              resourceType={resourceType} 
+              currentResourceValue={value}
+              onHideModal={() => setShowModal(false)} 
+              onClickSpend={handleClickSpend}
+              onClickGain={handleClickGain}  />
         </div>
+    );
+}
+
+interface ProductionSetterProps {
+    resourceType: Resource;
+    currentValue: number;
+    onDecrementValue: () => void;
+    onIncrementValue: () => void;
+}
+
+// ProductionSetter allows modification of a particular resource's production 
+// (incrementing/decrementing the value appropriately). For TR, this would mean 
+// incrementing/decrementing the actual rating. For all other resources, 
+// this changes the production rate.
+const ProductionSetter: React.FC<ProductionSetterProps> = ({resourceType, currentValue, onDecrementValue, onIncrementValue}) => {
+    const isDecrementDisabled = resourceType === Resource.Megacredits ? currentValue <= -5 : currentValue <= 0;
+    return (
+        <div className="ProductionSetter">
+            <Button size="lg" onClick={onDecrementValue} disabled={isDecrementDisabled}>-</Button>
+            <div>{currentValue}</div>
+            <Button size="lg" onClick={onIncrementValue}>+</Button>
+        </div>
+    );
+}
+
+
+interface ResourceSpendGainModalProps {
+    modalVisible: boolean;
+    resourceType: Resource;
+    currentResourceValue: number;
+    onHideModal: () => void;
+    onClickGain: (resourceAmount: number) => void;
+    onClickSpend: (resourceAmount: number) => void;
+}
+const ResourceSpendGainModal: React.FC<ResourceSpendGainModalProps> = ({
+    modalVisible,
+    resourceType,
+    currentResourceValue,
+    onHideModal,
+    onClickGain,
+    onClickSpend,
+}) => {
+    const [numUnits, setNumUnits] = React.useState(0);
+
+    const handleHideModal = () => {
+        // Trigger prop to hide the modal from view.
+        onHideModal();
+
+        // Reset the inputted units
+        setNumUnits(0);
+    }
+
+    const handleClickSpend = () => {
+        onClickSpend(numUnits);
+        handleHideModal();
+    }
+
+
+    const handleClickGain = () => {
+        onClickGain(numUnits);
+        handleHideModal();
+    }
+
+    const handleChangeInput = (inputChange: React.ChangeEvent<HTMLInputElement>) => {
+        const inputValueAsNum = Number(inputChange.target.value);
+        if (isNaN(inputValueAsNum) || inputValueAsNum < 0) {
+            return;
+        }
+
+        setNumUnits(inputValueAsNum);
+    }
+
+    const isValidSpend = numUnits <= currentResourceValue;
+
+    return (
+        <Modal show={modalVisible} onHide={handleHideModal}>
+        <Modal.Header closeButton>
+            <Modal.Title>Spend/Gain {ResourceToLabel[resourceType]}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+            <div 
+            className="Modal-currentResourceValue"
+            style={{"backgroundColor": ResourceToPrimaryColor[resourceType]}}>
+                Current resource value: {currentResourceValue} 
+            </div>
+            <div 
+            className="Modal-userInput">
+                <InputGroup>
+                    <InputGroup.Text>Amount</InputGroup.Text>
+                    <input inputMode="numeric" onChange={handleChangeInput}/>
+                </InputGroup>
+            </div>
+        </Modal.Body>
+        <Modal.Footer>
+            <div className="Modal-footer">
+                <Button size="lg" variant="danger" onClick={handleClickSpend} disabled={!isValidSpend}>
+                    {isValidSpend ? `Spend ${numUnits}` : `Cannot Spend`}
+                </Button>
+                <Button size="lg" variant="success" onClick={handleClickGain}>
+                    Gain {numUnits}
+                </Button>
+            </div>
+        </Modal.Footer>
+    </Modal>
     );
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,17 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
+}
+
+#root {
+  height: 100%;
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -7,3 +7,13 @@ export enum Resource {
     Energy,
     Heat
 }
+
+export const ResourceToLabel = {
+    [Resource.TerraformingRating]: "Terraforming Rating",
+    [Resource.Megacredits]: "Megacredits",
+    [Resource.Steel]: "Steel",
+    [Resource.Titanium]: "Titanium",
+    [Resource.Plants]: "Plants",
+    [Resource.Energy]: "Energy",
+    [Resource.Heat]: "Heat",
+}


### PR DESCRIPTION
App now loads the following view:

<img width="1279" alt="Screen Shot 2020-12-26 at 3 01 22 PM" src="https://user-images.githubusercontent.com/11758676/103160533-3c24c100-478b-11eb-9c92-327a14cb1419.png">


- App renders a PlayerBoard component, which wraps all the resource tiles
- Add basic styling to resource tiles (colors, rough sections)

TODO:
- Add real logic handlers to the -/+ buttons
- Clean up the 'generate' button

